### PR TITLE
Changes aimed at publishing the crate on `crates.io`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target
+**/*.rs.bk
+Cargo.lock
+.cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "dbase_parser"
 version = "0.1.0"
 authors = ["Seb Renauld <seb.renauld@gmail.com>"]
 edition = "2018"
+description = "A fast, efficient dbase DBF/DBT/FPT parser"
+license = "GPLv3"
+homepage = "https://github.com/srenauld/dbase"
+repository = "https://github.com/srenauld/dbase"
 
 [dependencies]
 chrono = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://github.com/srenauld/dbase"
 repository = "https://github.com/srenauld/dbase"
 
 [dependencies]
-chrono = "*"
-byteorder = "*"
+chrono = "0.4.8"
+byteorder = "1.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Seb Renauld <seb.renauld@gmail.com>"]
 edition = "2018"
 description = "A fast, efficient dbase DBF/DBT/FPT parser"
-license = "GPLv3"
+license = "MIT OR Apache-2.0"
 homepage = "https://github.com/srenauld/dbase"
 repository = "https://github.com/srenauld/dbase"
 

--- a/README.md
+++ b/README.md
@@ -55,3 +55,19 @@ If you've found a bug or issue, don't hesitate to file an issue. If you are
 parsing a file, don't forget to attach it to your issue; make sure to anonymize 
 the data if needed.
 
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0
+   ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license
+   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
Changes include:

- dual-licensing the code under Apache/MIT
- removing wildcard dependencies
- adding `homepage`, `repository`